### PR TITLE
Ignore static constructor

### DIFF
--- a/Remute.Tests/Model/StaticConstructor.cs
+++ b/Remute.Tests/Model/StaticConstructor.cs
@@ -1,0 +1,29 @@
+namespace Remutable.Tests.Model
+{
+    public class StaticConstructor
+    {
+        public string Property1 { get; }
+
+        static StaticConstructor()
+        {
+
+        }
+
+        public StaticConstructor(string property1)
+        {
+            Property1 = property1;
+        }
+    }
+
+    public class StaticFieldInit
+    {
+        public string Property1 { get; }
+
+        public static StaticFieldInit Default = new StaticFieldInit("Default");
+
+        public StaticFieldInit(string property1)
+        {
+            Property1 = property1;
+        }
+    }
+}

--- a/Remute.Tests/RemuteTests.cs
+++ b/Remute.Tests/RemuteTests.cs
@@ -155,5 +155,27 @@ namespace Remutable.Tests
 
             Assert.Fail();
         }
+
+        [TestMethod]
+        public void StaticConstructor_Success()
+        {
+            var original = new StaticConstructor("original");
+            var remute = new Remute();
+            var actual = remute.With(original, x => x.Property1, "updated value");
+            Assert.AreEqual("updated value", actual.Property1);
+            Assert.AreEqual("original", original.Property1);
+            Assert.AreNotSame(original, actual);
+        }
+
+        [TestMethod]
+        public void StaticFieldInitialization_Success()
+        {
+            var original = StaticFieldInit.Default;
+            var remute = new Remute();
+            var actual = remute.With(original, x => x.Property1, "updated value");
+            Assert.AreEqual("updated value", actual.Property1);
+            Assert.AreEqual("Default", original.Property1);
+            Assert.AreNotSame(original, actual);
+        }
     }
 }

--- a/Remute/Remute.cs
+++ b/Remute/Remute.cs
@@ -178,7 +178,7 @@ namespace Remutable
                 return setting.Constructor;
             }
 
-            var constructors = type.GetTypeInfo().DeclaredConstructors;
+            var constructors = type.GetTypeInfo().DeclaredConstructors.Where(ctor => !ctor.IsStatic);
 
             if (constructors.Count() != 1)
             {


### PR DESCRIPTION
If a class has a static constructor Remute throws an "Unable to find appropriate constructor" exception.

Since a static constructor isn't used to create an instance of the class it should be ignored. 

This also causes problems when the class doesn't have an explicit static constructor but does have some other type of static initialization (static fields for instance) because this implicitly generates a static constructor.